### PR TITLE
Handle case when webhook passes through multiple proxies before reaching the destination

### DIFF
--- a/src/django_paddle_billing/views.py
+++ b/src/django_paddle_billing/views.py
@@ -76,7 +76,7 @@ class PaddleWebhookView(View):
         - sending a django signal for each of the SUPPORTED_WEBHOOKS
         """
         payload = request.body.decode("utf-8")
-        paddle_ip = request.META.get("HTTP_X_FORWARDED_FOR", "")
+        paddle_ip = request.META.get("HTTP_X_FORWARDED_FOR", "").split(", ")[0]
         if app_settings.PADDLE_SANDBOX and paddle_ip not in app_settings.PADDLE_SANDBOX_IPS:
             return HttpResponseBadRequest("IP not allowed")
         elif not app_settings.PADDLE_SANDBOX and paddle_ip not in app_settings.PADDLE_IPS:


### PR DESCRIPTION
## Description

The current version only checks for a single IP address, which fails if I have multiple proxies set up (nginx -> cloudflared -> django). The improvement strips all IP addresses but the first, which should always be the Paddle IP address.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.

I started working through the final checkboxes but was hit with the issues I outlined in #60. I have a local test written and would like to finish the checklist before merging this in, if possible.