### PR TITLE
Support non-integer primary keys in account models

### DIFF
--- a/src/django_paddle_billing/models.py
+++ b/src/django_paddle_billing/models.py
@@ -547,7 +547,7 @@ class Subscription(PaddleBaseModel):
             pass
 
         if account_id is not None:
-            if not get_account_model().objects.filter(pk=int(account_id)).exists():
+            if not get_account_model().objects.filter(pk=account_id).exists():
                 error = f"Subscription: Account with id: {account_id} does not exist"
                 return None, False, error
 


### PR DESCRIPTION
## Description

Don't cast `account_id` to integer in order to support non-integer primary keys (e.g., UUID).

## Related Issue

https://github.com/websideproject/django-paddle-billing/issues/95

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
