### PR TITLE
Update dependency due to breaking pydantic changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "django>=4.2",
-  "paddle_billing_client>=0.2.13",
+  "paddle_billing_client>=0.2.14",
   "django_json_widget"
 ]
 


### PR DESCRIPTION
## Description

The api-client-pydantic breaks with pydantic >2.8.2, paddle-bliing-client sets as upper limit this version to avoid breaks, until the api-client package updates the relevant parts.

## Related Issue

https://github.com/websideproject/django-paddle-billing/issues/113