### PR TITLE
Paddle has changed the signature header name to "Paddle-Signature"

### DIFF
--- a/src/django_paddle_billing/views.py
+++ b/src/django_paddle_billing/views.py
@@ -84,7 +84,7 @@ class PaddleWebhookView(View):
             return HttpResponseBadRequest("IP not allowed")
 
         is_valid = validate_webhook_signature(
-            request.META.get("HTTP_PADDLE_SIGNATURE", ""), request.body, app_settings.PADDLE_SECRET_KEY
+            request.META.get("PADDLE-SIGNATURE", ""), request.body, app_settings.PADDLE_SECRET_KEY
         )
 
         if not is_valid:


### PR DESCRIPTION
Paddle has changed the signature header name to "Paddle-Signature"

## Description

According to the docs: https://developer.paddle.com/webhooks/signature-verification#get-header

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
